### PR TITLE
Keep reference to `compiler` in servers.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -30,6 +30,7 @@ export default function createAssetServer(assets, options) {
 	compiler.plugin('done', stats => events.emit('stats', stats));
 
 	return Object.assign(events, {
+		compiler,
 		listen(...args) {
 			server.listen(...args);
 		},

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -68,6 +68,7 @@ export default function createRenderServer(renderer, { watch }) {
 	});
 
 	return Object.assign(events, {
+		compiler: serverCompiler,
 		listen(_port) {
 			start = true;
 			port = _port;

--- a/lib/server.js
+++ b/lib/server.js
@@ -67,7 +67,7 @@ class Server extends EventEmitter {
 			// the location of the asset server. There is a bit of a race condition
 			// here where the stats event could occur after the listen one and not
 			// contain the updated path. This seems to work for now.
-			// assets.output.publicPath = url + '/';
+			this.assets.compiler.options.output.publicPath = url + '/';
 			mark('assets', url);
 			this.renderer.assets(url);
 		}).on('stats', stats => {


### PR DESCRIPTION
This is required for the `hot` workaround that involves adjusting the `publicPath` property of the asset webpack instance.