### PR TITLE
Make `lib` locally ignored.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
-lib
+./lib
+node_modules
+test


### PR DESCRIPTION
Otherwise it ignores the content in `dist` too.