### PR TITLE
Remove implicit `babel` hook.

### DIFF
--- a/bin/webpack-udev-server.js
+++ b/bin/webpack-udev-server.js
@@ -4,9 +4,6 @@ import yargs from 'yargs';
 import { createServer } from '../lib/server';
 import { resolve } from 'path'
 
-// cheating for now
-require("babel/register");
-
 const argv = yargs.argv;
 const server = createServer({
 	assets: require(resolve(argv.assets)),


### PR DESCRIPTION
Since `webpack` doesn't do this by default, it makes little sense for us to.