### PR TITLE
Bugfixes

### DIFF
--- a/bin/webpack-udev-server.js
+++ b/bin/webpack-udev-server.js
@@ -79,9 +79,8 @@ const server = createServer({
 });
 
 /* eslint no-console: 0 */
-
 server.on('ready', () => {
-  console.log(`💎  Ready.`);
+  console.log('💎  Ready.');
 });
 
 server.listen(process.env.PORT, () => {

--- a/bin/webpack-udev-server.js
+++ b/bin/webpack-udev-server.js
@@ -70,6 +70,7 @@ function load(entry) {
   return value;
 }
 
+global.__IN_DEV_SERVER = true;
 process.env.HOT = argv.hot;
 
 const server = createServer({

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -15,7 +15,10 @@ function hotness(target) {
   throw new TypeError();
 }
 
-export default function runtime({ target, hot }) {
+export default function runtime({ target, hot, force = false }) {
+  if (!force && !global.__IN_DEV_SERVER) {
+    return [ ];
+  }
   if (target === 'node') {
     return [
       './runtime/dev-server',

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,6 +66,16 @@ export default class Server extends http.Server {
         target: this.target('ws', req),
       });
     }));
+
+    // Handle proxy errors. These can occur if the proxied service crashes
+    // the connection dies with it resulting in a socket hang-up.
+    this.proxy.on('error', (error, req, res) => {
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'text/plain');
+      }
+      res.end(`Unable to fetch ${req.url}.`);
+    });
   }
 
   listen() {


### PR DESCRIPTION
See commits for details.

 * Only make `runtime` return data when running in server to prevent failed dev builds.
 * Handle proxy errors to prevent server death.

/cc @nealgranger