### PR TITLE
Support assets with multiple chunks.

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -41,10 +41,29 @@ export default function createRenderServer(renderer, options) {
     }
   }
 
+  function paths(base, entry) {
+    if (Array.isArray(entry)) {
+      return entry.map(value => paths(base, value));
+    } else if (typeof entry === 'string') {
+      return [ path.join(base, entry) ];
+    }
+    throw new TypeError('Invalid module path.');
+  }
+
+  function entry(module) {
+    const value = module.filter((entry) => /\.js$/.test(entry));
+    if (value.length > 0) {
+      return value[value.length - 1];
+    }
+    throw new TypeError('Module has no JavaScript files to run.');
+  }
+
   function _spawn() {
+    // `assetsByChunkName` can map to either a string OR an array – since one
+    // chunk can have multiple assets (e.g. source maps).
     const map = serverStats.toJson({ assets: true }).assetsByChunkName;
     const modules = Object.keys(map).map(key => {
-      return path.join(renderer.output.path, map[key]);
+      return paths(renderer.output.path, map[key]);
     });
     const env = {
       ...process.env,
@@ -56,7 +75,7 @@ export default function createRenderServer(renderer, options) {
     if (modules.length !== 1) {
       throw new Error('Must only export 1 entrypoint!');
     }
-    child = fork(modules[0], [  ], { env });
+    child = fork(entry(modules[0]), [  ], { env });
     child.on('message', (message) => {
       switch (message.type) {
       case 'ping':

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -69,6 +69,7 @@ export default function createRenderServer(renderer, options) {
       ...process.env,
       PORT: port,
       HAS_WEBPACK_ASSET_EVENTS: 1,
+      HAS_WEBPACK_STATS_EVENTS: 1,
     };
 
     // Only support one entrypoint right now. Maybe support more later.

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -169,7 +169,7 @@ export default function createRenderServer(renderer, options) {
         hash: true,
         version: false,
         timings: false,
-        assets: false,
+        assets: true,
         chunks: true,
         chunkModules: false,
         modules: false,

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -6,7 +6,7 @@ import path from 'path';
 
 export default function createRenderServer(renderer, options) {
   const serverCompiler = webpack(renderer);
-  const backoff = new Backoff({ min: 0, max: 1000 * 20 });
+  const backoff = new Backoff({ min: 0, max: 1000 * 5 });
   const events = new EventEmitter();
   let child = null;
   let addr = null;


### PR DESCRIPTION
Things like source maps result in multiple chunks (.js + .map). Previously this just bombed the server. Now we gracefully ignore those files.

Also
* Decrease max respawn timer to 5s.
* Add more sensible event environment variable.
* Forward assets for latest `webpack-assets`.