### PR TITLE
Kill process if HMR fails.

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -76,7 +76,9 @@ export default function createRenderServer(renderer, options) {
     if (modules.length !== 1) {
       throw new Error('Must only export 1 entrypoint!');
     }
-    child = fork(entry(modules[0]), [  ], { env });
+    const target = entry(modules[0]);
+    console.log(`▶️  ${target}`);
+    child = fork(target, [  ], { env });
     child.on('message', (message) => {
       switch (message.type) {
       case 'ping':

--- a/lib/runtime/dev-server.js
+++ b/lib/runtime/dev-server.js
@@ -18,3 +18,15 @@ process.on('message', function(message) {
 });
 
 process.send({ type: 'ping' });
+
+if (module.hot) {
+  // TODO: For cases like "The following modules couldn't be hot updated: (They
+  // would need a full reload!)" see if we can't figure out how to do the same
+  // thing.
+  // Just kill the process if we can't update; the server will restart for us.
+  module.hot.status((status) => {
+    if (status in {abort: 1, fail: 1}) {
+      process.exit(101);
+    }
+  });
+}


### PR DESCRIPTION
Handy to have. Unfortunately it doesn't deal with the case: "The following modules couldn't be hot updated: (They would need a full reload!)"

But it's a step in the right direction.
