### PR TITLE
Fix `socket.io` pathing.

### DIFF
--- a/lib/runtime/dev-client.js
+++ b/lib/runtime/dev-client.js
@@ -1,37 +1,31 @@
-/* global __resourceQuery, window, document */
+/* global __webpack_public_path__, window */
 /* eslint no-console: 0 */
 
 import url from 'url';
 import client from 'socket.io-client';
 import stripAnsi from 'strip-ansi';
 
-function invalidHost(hostname) {
-  return !hostname || hostname === '0.0.0.0';
-}
+function location() {
+  /* eslint camelcase: 0 */
+  const base = `${__webpack_public_path__}/socket.io`;
+  const parts = url.parse(base);
 
-function strip(node) {
-  return node.getAttribute('src').replace(/\/[^\/]+$/, '');
-}
-
-const scriptElements = document.getElementsByTagName('script');
-
-const urlParts = url.parse(
-  typeof __resourceQuery === 'string' && __resourceQuery ?
-    __resourceQuery.substr(1) :
-    `${strip(scriptElements[scriptElements.length - 1])}/socket.io`
-);
-
-const io = client.connect(
-  url.format({
-    protocol: urlParts.protocol,
-    auth: urlParts.auth,
-    hostname: invalidHost(urlParts.hostname) ?
-      window.location.hostname : urlParts.hostname,
-    port: urlParts.port,
-  }), {
-    path: urlParts.path === '/' ? null : urlParts.path,
+  if (base.charAt(0) === '/') {
+    return {
+      ...parts,
+      auth: window.location.auth,
+      hostname: window.location.hostname,
+      host: window.location.host,
+      port: window.location.port,
+      protocol: window.location.protocol,
+    };
   }
-);
+  return parts;
+}
+
+const parts = location();
+console.log('GOT PARTS', parts);
+const io = client.connect(parts.host, {path: parts.path});
 
 let hot = false;
 let initial = true;


### PR DESCRIPTION
It's just plain weird. `socket.io` bases things off rooms so `http://localhost/foo` is actually the room `foo`. This does _not_ specify where the `socket.io` connection actually lives. For that you need to specify a `{path}` argument.

See:
 * http://stackoverflow.com/questions/29511404