### PR TITLE
Add simple UI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "webpack-udev-server",
   "version": "0.5.0",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
+  "license": "CC0-1.0",
+  "repository": "izaakschroeder/webpack-udev-server",
   "main": "index.js",
   "scripts": {
+    "build": "./node_modules/.bin/babel -s -d . src",
+    "build:ui": "cd ui && npm i",
     "lint": "./node_modules/.bin/eslint .",
-    "prepublish": "./node_modules/.bin/babel -s -d . src",
+    "prepublish": "npm run build && npm run build:ui",
     "test": "npm run lint"
   },
   "bin": {
@@ -29,11 +33,13 @@
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
+    "babel-core": "^6.13.2",
     "babel-preset-metalab": "^0.2.0",
-    "eslint": "^1.10.3",
-    "eslint-config-metalab": "^2.0.0-beta.2",
+    "eslint": "^2.10.2",
+    "eslint-config-metalab": "^4.0.1",
     "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^0.12.1",
-    "eslint-plugin-react": "^3.16.0"
+    "eslint-plugin-import": "^1.13.0",
+    "eslint-plugin-lodash-fp": "^1.2.0",
+    "eslint-plugin-react": "^5.1.1"
   }
 }

--- a/src/lib/platform/web.js
+++ b/src/lib/platform/web.js
@@ -1,6 +1,7 @@
 import http from 'http';
 import ipc from '../ipc';
 import compose from 'lodash/flowRight';
+import identity from 'lodash/identity';
 import path from 'path';
 
 import thunk from 'http-middleware-metalab/middleware/thunk';
@@ -9,6 +10,8 @@ import {asset} from 'http-middleware-metalab/middleware/assets';
 import send from 'http-middleware-metalab/middleware/send';
 import status from 'http-middleware-metalab/middleware/status';
 import match from 'http-middleware-metalab/middleware/match';
+import serve from 'http-middleware-metalab/middleware/serve';
+import verbs from 'http-middleware-metalab/middleware/match/verbs';
 import connect from 'http-middleware-metalab/adapter/http';
 
 import MemoryFileSystem from 'memory-fs';
@@ -46,6 +49,12 @@ export default (compiler) => {
       });
       return () => result;
     }),
+    compiler.options.serve ? verbs.get(
+      compiler.options.output.publicPath,
+      serve({
+        root: compiler.options.serve,
+      })
+    ) : identity,
     compose(send(), status(404))
   )({request() {}, error() {}});
 
@@ -54,6 +63,7 @@ export default (compiler) => {
     const path = compiler.options.output.publicPath;
     ipc.emit('proxy', {
       url: `http://localhost:${address.port}${path}`,
+      token: compiler.options.token,
     });
   });
 

--- a/src/lib/runtime/common.js
+++ b/src/lib/runtime/common.js
@@ -13,7 +13,7 @@ export default ({reload}) => {
 
   // Monitor our own stats for changes. Other services may call `watch` for
   // things they are interested in.
-  ipc.emit('watch-stats', __webpack_dev_token__);
+  ipc.emit('watch', __webpack_dev_token__);
 
   ipc.on('stats', (stats) => {
     // Ignore everything but the update we want. Other stats may end up

--- a/src/lib/runtime/dev-server.js
+++ b/src/lib/runtime/dev-server.js
@@ -1,4 +1,4 @@
-/* global __webpack_public_path__ */
+/* global __webpack_public_path__, __webpack_dev_token__ */
 import http from 'http';
 import ipc from '../ipc';
 import runtime from './common';
@@ -13,6 +13,7 @@ http.Server.prototype.listen = function() {
     const path = __webpack_public_path__ || '/'; // eslint-disable-line
     ipc.emit('proxy', {
       url: `http://localhost:${address.port}${path}`,
+      token: __webpack_dev_token__, // eslint-disable-line
     });
   });
   listen.apply(this, arguments);

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,3 +1,9 @@
+import keyBy from 'lodash/fp/keyBy';
+import filter from 'lodash/fp/filter';
+import map from 'lodash/fp/map';
+import flow from 'lodash/fp/flow';
+import sortBy from 'lodash/fp/sortBy';
+
 export const kill = (child, cb = () => {}) => {
   let timeout = null;
   child.once('exit', () => {
@@ -11,4 +17,16 @@ export const kill = (child, cb = () => {}) => {
     child.kill('SIGTERM');
     timeout = null;
   }, 3000);
+};
+
+export const updateStats = (previous, next) => {
+  const newAssets = keyBy('name', next.assets);
+  const oldAssets = flow(
+    filter(({name}) => !newAssets[name]),
+    map((asset) => ({...asset, old: true}))
+  )(previous.assets);
+  return {
+    ...next,
+    assets: sortBy('name', [...oldAssets, ...next.assets]),
+  };
 };

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>webpack</title>
+    <link rel="stylesheet" href="/__webpack_udev/styles.css"/>
+  </head>
+  <body>
+    <div id="main">Loading...</div>
+    <script type="text/javascript" src="/__webpack_udev/web.js"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "webpack-udev-server-ui",
+  "version": "0.1.0",
+  "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
+  "description": "Simple UI for monitoring the server.",
+  "scripts": {
+    "build": "./node_modules/.bin/webpack -p --config webpack.config.babel.js",
+    "prepublish": "npm run build"
+  },
+  "dependencies": {
+    "babel-core": "^6.13.2",
+    "classnames": "^2.2.5",
+    "copy-webpack-plugin": "^3.0.1",
+    "lodash": "^4.1.0",
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2",
+    "redux-actions": "^0.10.1",
+    "redux-thunk": "^2.1.0",
+    "socket.io-client": "^1.3.7",
+    "webpack": "^1.12.2",
+    "webpack-config-babel": "^0.2.0",
+    "webpack-config-source-maps": "^0.2.2",
+    "webpack-partial": "^1.3.0"
+  }
+}

--- a/ui/src/.eslintrc
+++ b/ui/src/.eslintrc
@@ -1,0 +1,6 @@
+env:
+  browser: true
+extends:
+  - metalab
+  - metalab/react
+  - metalab/rules/lodash-fp

--- a/ui/src/actions.js
+++ b/ui/src/actions.js
@@ -1,0 +1,6 @@
+import {PUT_STATS, COMPILE, PUT_ROUTE} from './types';
+import {createAction} from 'redux-actions';
+
+export const putStats = createAction(PUT_STATS);
+export const putRoute = createAction(PUT_ROUTE);
+export const compile = createAction(COMPILE);

--- a/ui/src/app.js
+++ b/ui/src/app.js
@@ -1,0 +1,113 @@
+import {createElement} from 'react';
+import map from 'lodash/fp/map';
+import flow from 'lodash/fp/flow';
+import values from 'lodash/fp/values';
+import filter from 'lodash/fp/filter';
+import {connect} from 'react-redux';
+import classNames from 'classnames';
+
+const Asset = ({name, old, publicPath}) => (
+  <li
+    className={classNames({
+      old,
+    })}
+  >
+    <a href={`${publicPath}${name}`}>{name}</a>
+  </li>
+);
+
+const Assets = ({assets, publicPath}) => (
+  <div>
+    <h2>Assets</h2>
+    <ul>
+      {map((asset) => (
+        <Asset
+          publicPath={publicPath}
+          {...asset}
+          key={asset.name}
+        />
+      ), assets)}
+    </ul>
+  </div>
+);
+
+const Routes = ({routes}) => (
+  <ul>
+    {map(({path, url}) => (
+      <li>
+        <a href={path}>{path}</a> <i className='fa fa-arrow-right'/> {url}
+      </li>
+    ), routes)}
+  </ul>
+);
+
+const ErrorThing = ({errors}) => (
+  <span className='errors'>
+    <i className='fa fa-exclamation-circle'/> {errors.length}
+  </span>
+);
+
+const WarningThing = ({warnings}) => (
+  <span className='warnings'>
+    <i className='fa fa-exclamation-triangle'/> {warnings.length}
+  </span>
+);
+
+const StatsItem = (({
+  token,
+  hash,
+  assets,
+  publicPath,
+  routes,
+  errors,
+  compiling,
+  warnings,
+  file,
+}) => (
+  <div
+    className={classNames({
+      errors: errors.length > 0,
+      warnings: warnings.length > 0,
+      instance: true,
+    })}
+  >
+    <h1>webpack</h1>
+    <div>
+      <ErrorThing errors={errors}/> <WarningThing warnings={warnings}/>
+    </div>
+    <div className='byline'>
+      {file}
+      <br/>
+      compilation token: {token}
+      <br/>
+      hash: {hash}
+    </div>
+    <h2>Routes</h2>
+    <Routes routes={routes}/>
+    {!compiling
+      ? <Assets publicPath={publicPath} assets={assets}/>
+      : 'Compiling...'
+    }
+  </div>
+));
+
+const List = (({stats}) => {
+  return (
+    <div>
+      {map((props) => <StatsItem {...props} key={props.token}/>, stats)}
+    </div>
+  );
+});
+
+const ConnectedList = connect(({stats, routes}) => {
+  const result = flow(
+    values,
+    map((stats) => ({
+      ...stats,
+      routes: filter({token: stats.token}, routes),
+    }))
+  )(stats);
+  return {stats: result};
+})(List);
+
+export default ConnectedList;

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,0 +1,33 @@
+import client from 'socket.io-client';
+import {createElement} from 'react';
+import {render} from 'react-dom';
+import {Provider} from 'react-redux';
+
+import App from './app';
+import createStore from './store';
+import {putStats, putRoute, compile} from './actions';
+
+const store = createStore();
+
+const Root = ({store}) => (
+  <Provider store={store}><App/></Provider>
+);
+
+const element = document.getElementById('main');
+render(<Root store={store}/>, element);
+
+const io = client(process.env.IPC_URL);
+
+io.on('stats', (stats) => {
+  store.dispatch(putStats(stats));
+});
+
+io.on('compile', (stats) => {
+  store.dispatch(compile(stats));
+});
+
+io.on('proxy', (route) => {
+  store.dispatch(putRoute(route));
+});
+
+io.emit('watch');

--- a/ui/src/reducer.js
+++ b/ui/src/reducer.js
@@ -1,0 +1,47 @@
+import {PUT_STATS, COMPILE, PUT_ROUTE} from './types';
+import {handleActions} from 'redux-actions';
+
+export default handleActions({
+  [PUT_STATS]: (state, {payload: stats}) => {
+    return {
+      ...state,
+      stats: {
+        ...state.stats,
+        [stats.token]: {
+          ...stats,
+          compiling: false,
+        },
+      },
+    };
+  },
+  [PUT_ROUTE]: (state, {payload: route}) => {
+    return {
+      ...state,
+      routes: {
+        ...state.routes,
+        [route.path]: route,
+      },
+    };
+  },
+  [COMPILE]: (state, {payload: stats}) => {
+    const previous = state.stats[stats.token];
+    return {
+      ...state,
+      stats: {
+        ...state.stats,
+        [stats.token]: previous ? {
+          ...previous,
+          compiling: true,
+        } : {
+          errors: [],
+          warnings: [],
+          assets: [],
+          ...stats,
+        },
+      },
+    };
+  },
+}, {
+  stats: {},
+  routes: {},
+});

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,0 +1,9 @@
+import {createStore, compose, applyMiddleware} from 'redux';
+import thunk from 'redux-thunk';
+
+import reducer from './reducer';
+
+export default (initialState) => compose(
+  applyMiddleware(thunk),
+  window.devToolsExtension ? window.devToolsExtension() : (f) => f
+)(createStore)(reducer, initialState);

--- a/ui/src/types.js
+++ b/ui/src/types.js
@@ -1,0 +1,3 @@
+export const PUT_STATS = 'PUT_STATS';
+export const PUT_ROUTE = 'PUT_ROUTE';
+export const COMPILE = 'COMPILE';

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,0 +1,131 @@
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css);
+
+/**
+ * Ensure content spans at least the size of the browser window.
+ * See: https://codepen.io/absolutholz/post/html-and-body-element-height-100
+ * ==========================================================================
+ */
+html {
+  height: 100%;
+}
+body {
+  min-height: 100%;
+}
+
+/**
+ * Consistent `box-sizing`.
+ * See: http://www.paulirish.com/2012/box-sizing-border-box-ftw/
+ * ==========================================================================
+ */
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+/**
+ * CSS reset for browser consistency.
+ * See: http://cssreset.com/scripts/eric-meyer-reset-css/
+ * ==========================================================================
+ */
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+  color: inherit;
+  font: inherit;
+	vertical-align: baseline;
+}
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
+/**
+ * Global tag styles.
+ * ==========================================================================
+ */
+
+body {
+  line-height: 1.45;
+  font-weight: 400;
+  font-family: 'Open Sans', sans-serif;
+  color: #333;
+}
+
+a {
+  text-decoration: none;
+}
+
+.old {
+  color: #ccc;
+}
+
+.errors {
+  color: #D8000C;
+}
+
+.warnings {
+  color: #E6BB00;
+}
+
+.instance {
+  border: solid 1px #c0c0c0;
+  padding: 20px;
+  margin: 20px;
+}
+
+h1, h2, h3, h4 {
+  margin: 1.414em 0 0.5em;
+  font-weight: inherit;
+  line-height: 1.2;
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.999em;
+  font-weight: 800;
+  color: #000;
+}
+
+h2 {
+  font-size: 1em;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: #000;
+}
+
+.byline {
+  font-size: 0.707;
+  color: #c0c0c0;
+}

--- a/ui/webpack.config.babel.js
+++ b/ui/webpack.config.babel.js
@@ -1,0 +1,32 @@
+import compose from 'lodash/fp/compose';
+import babel from 'webpack-config-babel';
+import sourceMaps from 'webpack-config-source-maps';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
+import path from 'path';
+import {DefinePlugin} from 'webpack';
+
+const context = __dirname;
+
+export default compose(
+  babel(),
+  sourceMaps()
+)({
+  target: 'web',
+  context,
+  entry: './src/index.js',
+  output: {
+    filename: 'web.js',
+    path: path.join(context, 'dist'),
+    publicPath: '/__webpack_udev',
+  },
+  serve: context,
+  plugins: [
+    new CopyWebpackPlugin([
+      {from: './index.html'},
+      {from: './styles.css'},
+    ]),
+    new DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+  ],
+});


### PR DESCRIPTION
Non-standard extension to the `webpack` config object: `serve`. Files in this directory will be served alongside the generated assets at `output.publicPath`. The generated assets take precedent over the served local files.

Simple `react` + `redux` app which displays information about the various stats objects generated by `webpack`.

Set environment variable `WEBPACK_DEV_UI` to enable hacking on the UI with webpack itself. The UI will be added as its own webpack config to the development server – a kind of self-hosting if you will.

It's not that pretty but it's a start and will do the job for now.

/cc @nealgranger